### PR TITLE
[FEAT]MemberController 유효성 검사 및 mailService 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ dependencies {
 
 	//타입리프 사용자 로그인 확인
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
+	//유효성 검사
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '3.2.0'
 
 }
 

--- a/front/src/configs/routes.config/authDemoRoute.js
+++ b/front/src/configs/routes.config/authDemoRoute.js
@@ -85,7 +85,7 @@ const authDemoRoute = [
         key: 'authentication.forgotPasswordSimple',
         path: `${AUTH_PREFIX_PATH}/forgot-password-simple`,
         component: React.lazy(() =>
-            import('views/auth-demo/ForgotPassword/ForgotPasswordSimple')
+            import('views/auth-demo/ForgotId/ForgotPasswordSimple')
         ),
         authority: [ADMIN, USER],
         meta: {
@@ -98,7 +98,7 @@ const authDemoRoute = [
         key: 'authentication.forgotPasswordSide',
         path: `${AUTH_PREFIX_PATH}/forgot-password-side`,
         component: React.lazy(() =>
-            import('views/auth-demo/ForgotPassword/ForgotPasswordSide')
+            import('views/auth-demo/ForgotId/ForgotPasswordSide')
         ),
         authority: [ADMIN, USER],
         meta: {
@@ -111,7 +111,7 @@ const authDemoRoute = [
         key: 'authentication.forgotPasswordCover',
         path: `${AUTH_PREFIX_PATH}/forgot-password-cover`,
         component: React.lazy(() =>
-            import('views/auth-demo/ForgotPassword/ForgotPasswordCover')
+            import('views/auth-demo/ForgotId/ForgotPasswordCover')
         ),
         authority: [ADMIN, USER],
         meta: {

--- a/front/src/configs/routes.config/authRoute.js
+++ b/front/src/configs/routes.config/authRoute.js
@@ -17,8 +17,8 @@ const authRoute = [
     },
     {
         key: 'forgotPassword',
-        path: `/forgot-password`,
-        component: React.lazy(() => import('views/auth/ForgotPassword')),
+        path: `/forgotId`,
+        component: React.lazy(() => import('views/auth/ForgotId')),
         // component: React.lazy(() => import('views/member_jaegun/ForgotPassword')),
         authority: [],
     },

--- a/front/src/services/AuthService.js
+++ b/front/src/services/AuthService.js
@@ -13,7 +13,7 @@ export async function apiSignIn(data) {
 export async function apiSignUp(data) {
     return ApiService.fetchData({
 
-        url: 'member/sign-up',
+        url: '/member/sign-up',
         method: 'post',
         data,
     })
@@ -22,7 +22,7 @@ export async function apiSignUp(data) {
 export async function apiForgotPassword(data) {
     return ApiService.fetchData({
 
-        url: `member/searchId/${data.email}`,
+        url: `/member/searchId/${data.email}`,
         method: 'get',
         data,
     })
@@ -31,7 +31,7 @@ export async function apiForgotPassword(data) {
 export async function apiResetPassword(data) {
     return ApiService.fetchData({
         
-        url: 'member/searchPassword',
+        url: '/member/searchPassword',
         method: 'post',
         data,
     })

--- a/front/src/views/auth-demo/ForgotId/ForgotPasswordCover.js
+++ b/front/src/views/auth-demo/ForgotId/ForgotPasswordCover.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import ForgotPasswordForm from 'views/auth/ForgotPassword/ForgotPasswordForm'
+import ForgotIdForm from 'views/auth/ForgotId/ForgotIdForm'
 import Cover from 'components/layout/AuthLayout/Cover'
 
 const ForgotPasswordCover = (props) => {
     return (
         <Cover>
-            <ForgotPasswordForm
+            <ForgotIdForm
                 disableSubmit={true}
                 signInUrl="/auth/sign-in-cover"
                 {...props}

--- a/front/src/views/auth-demo/ForgotId/ForgotPasswordSide.js
+++ b/front/src/views/auth-demo/ForgotId/ForgotPasswordSide.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import ForgotPasswordForm from 'views/auth/ForgotPassword/ForgotPasswordForm'
+import ForgotIdForm from 'views/auth/ForgotId/ForgotIdForm'
 import Side from 'components/layout/AuthLayout/Side'
 
 const ForgotPasswordCover = (props) => {
     return (
         <Side>
-            <ForgotPasswordForm
+            <ForgotIdForm
                 disableSubmit={true}
                 signInUrl="/auth/sign-in-side"
                 {...props}

--- a/front/src/views/auth-demo/ForgotId/ForgotPasswordSimple.js
+++ b/front/src/views/auth-demo/ForgotId/ForgotPasswordSimple.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import ForgotPasswordForm from 'views/auth/ForgotPassword/ForgotPasswordForm'
+import ForgotIdForm from 'views/auth/ForgotId/ForgotIdForm'
 import Simple from 'components/layout/AuthLayout/Simple'
 
 const ForgotPasswordSimple = (props) => {
     return (
         <Simple>
-            <ForgotPasswordForm
+            <ForgotIdForm
                 disableSubmit={true}
                 signInUrl="/auth/sign-in-simple"
                 {...props}

--- a/front/src/views/auth/ForgotId/ForgotIdForm.js
+++ b/front/src/views/auth/ForgotId/ForgotIdForm.js
@@ -10,7 +10,7 @@ const validationSchema = Yup.object().shape({
     email: Yup.string().required('이메일을 다시 확인해주세요.'),
 })
 
-const ForgotPasswordForm = (props) => {
+const ForgotIdForm = (props) => {
     const { disableSubmit = false, className, signInUrl = '/sign-in' } = props
 
     const [emailSent, setEmailSent] = useState(false);
@@ -114,4 +114,4 @@ const ForgotPasswordForm = (props) => {
     )
 }
 
-export default ForgotPasswordForm
+export default ForgotIdForm;

--- a/front/src/views/auth/ForgotId/index.js
+++ b/front/src/views/auth/ForgotId/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import ForgotIdForm from './ForgotIdForm'
+
+const ForgotId = () => {
+    return <ForgotIdForm disableSubmit={false} />
+}
+
+export default ForgotId

--- a/front/src/views/auth/ForgotPassword/index.js
+++ b/front/src/views/auth/ForgotPassword/index.js
@@ -1,8 +1,0 @@
-import React from 'react'
-import ForgotPasswordForm from './ForgotPasswordForm'
-
-const ForgotPassword = () => {
-    return <ForgotPasswordForm disableSubmit={false} />
-}
-
-export default ForgotPassword

--- a/front/src/views/auth/SignIn/SignInForm.js
+++ b/front/src/views/auth/SignIn/SignInForm.js
@@ -2,7 +2,6 @@ import React from 'react'
 import {
     Input,
     Button,
-    Checkbox,
     FormItem,
     FormContainer,
     Alert,
@@ -127,7 +126,7 @@ const SignInForm = (props) => {
                                         </ActionLink>
                                     </div>
                                 </div>
-                                <div className="mt-2">    
+                                <div className="mt-2">
                                     <span>계정이 없으신가요? </span>
                                     <ActionLink to={signUpUrl}>회원가입</ActionLink>
                                 </div>

--- a/front/src/views/auth/SignUp/SignUpBodyForm.js
+++ b/front/src/views/auth/SignUp/SignUpBodyForm.js
@@ -23,8 +23,6 @@ const validationSchema = Yup.object().shape({
 
 
 const SignUpBodyForm = ({ formData, className, signInUrl }) => {
-    // const { disableSubmit = false, className, signInUrl = '/sign-in' } = props
-    // const { signUp } = useAuth()
     const disableSubmit = false;
     const [message, setMessage] = useTimeOutMessage()
 

--- a/src/main/java/com/fcc/PureSync/common/constant/EmailConstant.java
+++ b/src/main/java/com/fcc/PureSync/common/constant/EmailConstant.java
@@ -7,8 +7,8 @@ public final class EmailConstant {
     public static final String EMAIL_TITLE = "회원 링크 인증";
 
     //아래 위치 변경 필요
-    public static final String LOCAL_DOMAIN="http://localhost:9000";
-    public static final String VERIFY_DOMAIN="http://localhost:4000";
+    public static final String LOCAL_DOMAIN="http://localhost:9000"; // 백엔드 // 컨트롤러
+    public static final String VERIFY_DOMAIN="http://localhost:4000"; //프론트
     public static final String AWS_DOMAIN="";
 
     public static final Integer MEMBER_ENABLED_LEVEL=4;

--- a/src/main/java/com/fcc/PureSync/config/SecurityConfig.java
+++ b/src/main/java/com/fcc/PureSync/config/SecurityConfig.java
@@ -79,7 +79,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .portMapper(portMapper -> portMapper
                         .http(9000)
-                        .mapsTo(9443));
+                        .mapsTo(9443))
+                .formLogin(config-> config.disable());
         return httpSecurity.build();
     }
 

--- a/src/main/java/com/fcc/PureSync/controller/MailController.java
+++ b/src/main/java/com/fcc/PureSync/controller/MailController.java
@@ -25,7 +25,7 @@ public class MailController {
             , HttpServletResponse response) throws IOException {
         ResultDto resultDto = mailService.checkVerificationCode(email, verificationCode);
         if (resultDto!=null)
-            response.sendRedirect(EmailConstant.VERIFY_DOMAIN +"/sign-in");
+            response.sendRedirect(EmailConstant.VERIFY_DOMAIN +"/landing");
         return resultDto;
     }
 

--- a/src/main/java/com/fcc/PureSync/controller/MemberController.java
+++ b/src/main/java/com/fcc/PureSync/controller/MemberController.java
@@ -7,6 +7,10 @@ import com.fcc.PureSync.dto.SignupDto;
 import com.fcc.PureSync.jwt.CustomUserDetails;
 import com.fcc.PureSync.service.MemberService;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,27 +26,27 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup") // 회원가입
-    public ResultDto signup (@RequestBody SignupDto signupDto) {
+    public ResultDto signup (@RequestBody @Valid SignupDto signupDto) {
         return memberService.signup(signupDto);
     }
 
     @PostMapping("/login")  // 로그인
-    public ResultDto login(@RequestBody LoginDto loginDto, HttpServletResponse response) {
+    public ResultDto login(@RequestBody @Valid LoginDto loginDto, HttpServletResponse response) {
         return memberService.login(loginDto);
     }
 
     @GetMapping("/check-duplicate/{field}/{value}")
-    public ResultDto checkDuplicate(@PathVariable String field, @PathVariable String value) {
+    public ResultDto checkDuplicate(@PathVariable @NotBlank String field, @PathVariable @NotBlank String value) {
         return memberService.checkDuplicate(field, value);
     }
 
     @PostMapping("/searchPassword")
-    public ResultDto searchPassword(@RequestBody FindPasswordDto findPasswordDto){
+    public ResultDto searchPassword(@RequestBody @Valid FindPasswordDto findPasswordDto){
     return memberService.searchPassword(findPasswordDto);
     }
 
     @GetMapping("/searchId/{memEmail}")
-    public ResultDto searchId(@PathVariable("memEmail") String memEmail){
+        public ResultDto searchId(@PathVariable("memEmail") @Email String memEmail){
         return memberService.searchId(memEmail);
     }
 

--- a/src/main/java/com/fcc/PureSync/dto/FindPasswordDto.java
+++ b/src/main/java/com/fcc/PureSync/dto/FindPasswordDto.java
@@ -1,5 +1,7 @@
 package com.fcc.PureSync.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 @Getter
@@ -7,6 +9,8 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FindPasswordDto {
+    @Pattern(regexp =  "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$")
     private String memId;
+    @Email
     private String memEmail;
 }

--- a/src/main/java/com/fcc/PureSync/dto/LoginDto.java
+++ b/src/main/java/com/fcc/PureSync/dto/LoginDto.java
@@ -1,5 +1,6 @@
 package com.fcc.PureSync.dto;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 @NoArgsConstructor
@@ -7,7 +8,8 @@ import lombok.*;
 @ToString
 @Getter
 public class LoginDto {
-
+    @Pattern(regexp =  "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$")
     private String memId;
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$")
     private String memPassword;
 }

--- a/src/main/java/com/fcc/PureSync/dto/SignupDto.java
+++ b/src/main/java/com/fcc/PureSync/dto/SignupDto.java
@@ -1,21 +1,37 @@
 package com.fcc.PureSync.dto;
 
 import com.fcc.PureSync.entity.BaseEntity;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 public class SignupDto extends BaseEntity {
 
+    @Pattern(regexp =  "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$")
     String memId;
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$")
     String memPassword;
+    @NotBlank
     String memNick;
+    @Email
     String memEmail;
+    @Past
     String memBirth;
-    String memGender;
+    @Length(max=1)
+     String memGender;
     //
+    @DecimalMax(value = "300.00")
+    @Positive
     Double bodyHeight;
+    @DecimalMax(value = "500.00")
+    @Positive
     Double bodyWeight;
+    @Max(10000)
+    @Positive
     Double bodyWishWeight;
+    @Max(10000)
+    @Positive
     Double bodyWishConscal;
 
 }

--- a/src/main/java/com/fcc/PureSync/service/MailService.java
+++ b/src/main/java/com/fcc/PureSync/service/MailService.java
@@ -91,6 +91,7 @@ public class MailService {
         } catch (Exception e) {
             e.printStackTrace();
             throw new CustomException(SEND_ERROR);
+
         }
     }
 

--- a/src/main/java/com/fcc/PureSync/service/MailService.java
+++ b/src/main/java/com/fcc/PureSync/service/MailService.java
@@ -41,7 +41,6 @@ public class MailService {
         String txt = String.format("%s/api/mail/verify?verificationCode=%s&email=%s", EmailConstant.LOCAL_DOMAIN, linkCode,newMemberEmail);
         verificationCodeDao.saveVerificationCode(newMemberEmail, linkCode);
         sendMail(newMemberEmail, EmailConstant.EMAIL_TITLE, txt);
-
     }
 
     //링크 코드 비교

--- a/src/main/java/com/fcc/PureSync/service/MemberService.java
+++ b/src/main/java/com/fcc/PureSync/service/MemberService.java
@@ -147,11 +147,7 @@ public class MemberService {
         Member member = memberRepository.findByMemEmail(findPasswordDto.getMemEmail()).orElseThrow(() -> new CustomException(NOT_FOUND_EMAIL));
         String newPassword = RandomStringGenerator.generateRandomPassword(12);
         updateTemporaryPassword(member, newPassword);
-        Instant beforesearchPasswordmailService = Instant.now();
         mailService.sendTemporaryPassword(findPasswordDto.getMemEmail(), newPassword);
-        Instant aftersearchPasswordmailService = Instant.now();
-        long sendMail = Duration.between(beforesearchPasswordmailService, aftersearchPasswordmailService).toMillis();
-        System.out.println("메일 전송 실행 시간(ms): " + sendMail);
         return handleResultDtoFromFindPassword();
     }
 
@@ -184,9 +180,11 @@ public class MemberService {
     }
 
     private ResultDto getResultDtoToDuplicate(String msg) {
+        HashMap<String,Object> resultMap = new HashMap<>();
         return ResultDto.builder()
                 .code(HttpStatus.OK.value())
                 .httpStatus(HttpStatus.OK)
+                .data(resultMap)
                 .message(msg)
                 .build();
     }


### PR DESCRIPTION
- [ ] MailService 수정 (인증 후 랜딩 페이지 이동)
- [ ] 백엔드 측 유효성 검사 추가
----------------------------------------------------------------
참고로 이것을 풀 받으면 유효성 검사에서 탈락한 id들은 로그인이 되지않습니다.
조건1.
아이디는 영문 숫자 포함한 8글자 이상
조건2.
비밀번호는 영문 숫자 특수 문자 포하함 8글자 이상

기존 onbody 사용하고 싶으시면
LoginDto에서 
 @Pattern(regexp =  "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$")
 @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$")
이 부분을 주석 처리하시면 로그인이 가능합니다.